### PR TITLE
Remove trailing spaces

### DIFF
--- a/SDMN/SDMN-Semantic.xsd
+++ b/SDMN/SDMN-Semantic.xsd
@@ -5,7 +5,7 @@
     xmlns:dmn="https://www.omg.org/spec/DMN/20191111/MODEL/"
     elementFormDefault="qualified"
     targetNamespace="https://www.omg.org/spec/SDMN/20211108/MODEL">
-   
+
     <xsd:import namespace="https://www.omg.org/spec/SCE/20211108/MODEL" schemaLocation="../SCE/SCE.xsd"/>
     <xsd:import namespace="https://www.omg.org/spec/DMN/20191111/MODEL/" schemaLocation="../DMN/DMN13.xsd"/>
 
@@ -15,15 +15,15 @@
         <xsd:attribute name="location" type="xsd:string" use="required"/>
         <xsd:attribute name="importType" type="xsd:anyURI" use="required"/>
     </xsd:complexType>
-    
+
     <xsd:element name="SDMNModel" type="sdmn:tSDMNModel">
         <xsd:annotation>
             <xsd:documentation>
-                The SDMNPackage class is the outermost containing object for all SDMN elements. It defines the scope of visibility and the namespace 
-                for all contained elements. The interchange of SDMN files will always be through one or more SDMNPackages. Specifically, an XML file 
+                The SDMNPackage class is the outermost containing object for all SDMN elements. It defines the scope of visibility and the namespace
+                for all contained elements. The interchange of SDMN files will always be through one or more SDMNPackages. Specifically, an XML file
                 for a Shared Data Model usually would be appended with a “.sdmn” label.
             </xsd:documentation>
-        </xsd:annotation>        
+        </xsd:annotation>
     </xsd:element>
     <xsd:complexType name="tSDMNModel">
         <xsd:complexContent>
@@ -31,14 +31,14 @@
                 <xsd:sequence>
                     <xsd:element maxOccurs="unbounded" minOccurs="0" name="definitions" type="sdmn:tSDMNDefinitions">
                         <xsd:annotation>
-                            <xsd:documentation> 
+                            <xsd:documentation>
                                 This is a list of the SDMNDefinitions that are included in the SDMNModel.
                             </xsd:documentation>
                         </xsd:annotation>
                     </xsd:element>
                     <xsd:element maxOccurs="unbounded" minOccurs="0" name="sdmnVocabulary" type="sdmn:tSDMNVocabulary">
                         <xsd:annotation>
-                            <xsd:documentation> 
+                            <xsd:documentation>
                                 This is a list of the SDMNVocabularies that are included in the SDMNModel.
                             </xsd:documentation>
                         </xsd:annotation>
@@ -47,15 +47,15 @@
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>
-    
+
     <xsd:element name="SDMNDefinitions" type="sdmn:tSDMNDefinitions">
         <xsd:annotation>
             <xsd:documentation>
-                The SDMNPackage class is the outermost containing object for all SDMN elements. It defines the scope of visibility and the namespace 
-                for all contained elements. The interchange of SDMN files will always be through one or more SDMNPackages. Specifically, an XML file 
+                The SDMNPackage class is the outermost containing object for all SDMN elements. It defines the scope of visibility and the namespace
+                for all contained elements. The interchange of SDMN files will always be through one or more SDMNPackages. Specifically, an XML file
                 for a Shared Data Model usually would be appended with a “.sdmn” label.
             </xsd:documentation>
-        </xsd:annotation>        
+        </xsd:annotation>
     </xsd:element>
     <xsd:complexType name="tSDMNDefinitions">
         <xsd:complexContent>
@@ -63,7 +63,7 @@
                 <xsd:sequence>
                     <xsd:element maxOccurs="unbounded" minOccurs="0" name="dataItem" type="sdmn:tDataItem">
                         <xsd:annotation>
-                            <xsd:documentation> 
+                            <xsd:documentation>
                                 This is a list of the Data Items that are included in the SDMNDefinitions.
                             </xsd:documentation>
                         </xsd:annotation>
@@ -78,10 +78,10 @@
                     <xsd:element maxOccurs="1" minOccurs="0" name="sharedDataModel" type="sdmn:tSharedDataModel">
                         <xsd:annotation>
                             <xsd:documentation>
-                                TBD... 
+                                TBD...
                             </xsd:documentation>
                         </xsd:annotation>
-                    </xsd:element>                    
+                    </xsd:element>
                 </xsd:sequence>
             </xsd:extension>
         </xsd:complexContent>
@@ -94,7 +94,7 @@
                 <xsd:sequence>
                     <xsd:element maxOccurs="unbounded" minOccurs="0" name="connector" type="sdmn:tConnector">
                         <xsd:annotation>
-                            <xsd:documentation> 
+                            <xsd:documentation>
                                 This is a list of the Connectors (Composition, Containment, Reference, and Data Association) that are included in the SharedDataModel.
                             </xsd:documentation>
                         </xsd:annotation>
@@ -103,21 +103,21 @@
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>
-    
+
     <xsd:element name="SDMNVocabulary" type="sdmn:tSDMNVocabulary" abstract="false">
         <xsd:annotation>
             <xsd:documentation>
-                This is a list of terms (SemanticReferences) that can be used to define the meaning of elements of 
-                SDMNVocabulary. Multiple Vocabularies can be defined. They are contained in an SDMNModel. 
+                This is a list of terms (SemanticReferences) that can be used to define the meaning of elements of
+                SDMNVocabulary. Multiple Vocabularies can be defined. They are contained in an SDMNModel.
             </xsd:documentation>
         </xsd:annotation>
     </xsd:element>
     <xsd:complexType name="tSDMNVocabulary">
         <xsd:complexContent>
-            <xsd:extension base="sce:tSCEVocabulary"/>            
+            <xsd:extension base="sce:tSCEVocabulary"/>
         </xsd:complexContent>
     </xsd:complexType>
-    
+
     <xsd:element name="DataItemModel" type="sdmn:tDataItemModel" substitutionGroup="sdmn:SharedDataModel"/>
     <xsd:complexType name="tDataItemModel">
         <xsd:complexContent>
@@ -125,7 +125,7 @@
                 <xsd:sequence>
                     <xsd:element maxOccurs="unbounded" minOccurs="0" ref="sdmn:DataItem">
                         <xsd:annotation>
-                            <xsd:documentation> 
+                            <xsd:documentation>
                                 Element Role: dataItemRef
                                 This is a list of the Connectors (Composition, Containment, Reference, and Data Association) that are included in the SharedDataModel.
                             </xsd:documentation>
@@ -135,13 +135,13 @@
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>
-    
+
     <xsd:element name="DataItem" type="sdmn:tDataItem">
         <xsd:annotation>
             <xsd:documentation>
                 A SDMN Data Item represents a common definition and structure for the data handling elements of the other BPM+ models.
             </xsd:documentation>
-        </xsd:annotation>        
+        </xsd:annotation>
     </xsd:element>
     <xsd:complexType name="tDataItem">
         <xsd:complexContent>
@@ -150,8 +150,8 @@
                     <xsd:element maxOccurs="1" minOccurs="0" name="metaDefinitionRef" type="xsd:QName">
                         <xsd:annotation>
                             <xsd:documentation>
-                                A reference to an itemDefinition that defines the Properties of the Data Item. The itemComponents of the ItemDefinition structure 
-                                map to the Properties of a CMMN Case File Item. Each of the itemComponents MUST be a simple type. 
+                                A reference to an itemDefinition that defines the Properties of the Data Item. The itemComponents of the ItemDefinition structure
+                                map to the Properties of a CMMN Case File Item. Each of the itemComponents MUST be a simple type.
                             </xsd:documentation>
                         </xsd:annotation>
                     </xsd:element>
@@ -159,16 +159,16 @@
                         <xsd:annotation>
                             <xsd:documentation>
                                 Element Role: preAssignement
-                                Specifies an optional pre-assignment LiteralExpression. The expression will provide values for one or more of the simple type 
-                                itemComponents of the ItemDefinition set for the Data Item. 
+                                Specifies an optional pre-assignment LiteralExpression. The expression will provide values for one or more of the simple type
+                                itemComponents of the ItemDefinition set for the Data Item.
                             </xsd:documentation>
                         </xsd:annotation>
                     </xsd:element>
                     <xsd:element maxOccurs="1" minOccurs="0" name="referenceTargetRef" type="xsd:QName">
                         <xsd:annotation>
                             <xsd:documentation>
-                                Zero or more source Data Item. For reference hierarchies of a Data Item, referenceSourceRef refers to the source of the Data Item. If 
-                                Data Item b is a referenceTargetRef of Data Item a, then referenceSourceRef of Data Item b is a. 
+                                Zero or more source Data Item. For reference hierarchies of a Data Item, referenceSourceRef refers to the source of the Data Item. If
+                                Data Item b is a referenceTargetRef of Data Item a, then referenceSourceRef of Data Item b is a.
                             </xsd:documentation>
                         </xsd:annotation>
                     </xsd:element>
@@ -176,7 +176,7 @@
                         <xsd:annotation>
                             <xsd:documentation>
                                 A reference to an itemDefinition that defines the detailed structure, which can be simple or complex, of the Data Item.
-                                A Data Item can have only one of dataItemRef, or typeDefinitionRef as a set attribute. None of them are required, though.  
+                                A Data Item can have only one of dataItemRef, or typeDefinitionRef as a set attribute. None of them are required, though.
                             </xsd:documentation>
                         </xsd:annotation>
                     </xsd:element>
@@ -200,13 +200,13 @@
             <xsd:extension base="sce:tSemanticReference"/>
         </xsd:complexContent>
     </xsd:complexType>
-    
+
     <xsd:element name="Assignment" type="sdmn:tAssignment">
         <xsd:annotation>
             <xsd:documentation>
                 tbd...
             </xsd:documentation>
-        </xsd:annotation>    
+        </xsd:annotation>
     </xsd:element>
     <xsd:complexType name="tAssignment">
         <xsd:complexContent>
@@ -214,9 +214,9 @@
                 <xsd:sequence>
                     <xsd:element minOccurs="1" maxOccurs="1" ref="dmn:expression">
                         <xsd:annotation>
-                            <xsd:documentation> 
+                            <xsd:documentation>
                                 Element Role: value
-                                The DMN Expression that evaluates the Assignment. 
+                                The DMN Expression that evaluates the Assignment.
                             </xsd:documentation>
                         </xsd:annotation>
                     </xsd:element>
@@ -230,7 +230,7 @@
             <xsd:documentation>
                 Defines the detailed structure, which can be simple or complex, of a Data Item.
             </xsd:documentation>
-        </xsd:annotation>        
+        </xsd:annotation>
     </xsd:element>
     <xsd:complexType name="tItemDefinition">
         <xsd:complexContent>
@@ -240,8 +240,8 @@
                         <xsd:annotation>
                             <xsd:documentation>
                                 Element Role: semanticReference
-                                A ItemDefinition can include multiple SemanticReference elements. This attribute was added because ItemDefinition is based on the 
-                                DMN ItemDefinition, which is not based on the SCE specification and thus, does not have a built in SemanticReference as part 
+                                A ItemDefinition can include multiple SemanticReference elements. This attribute was added because ItemDefinition is based on the
+                                DMN ItemDefinition, which is not based on the SCE specification and thus, does not have a built in SemanticReference as part
                                 of its definition.
                             </xsd:documentation>
                         </xsd:annotation>
@@ -249,27 +249,27 @@
                     <xsd:element minOccurs="1" maxOccurs="1" name="itemKindRef" type="sdmn:tItemKind">
                         <xsd:annotation>
                             <xsd:documentation>
-                                This defines the nature of the DataItem. Possible values are physical, information, conceptual, and others. 
-                                The default value is information. If the ItemDefinition has itemComponents or itemComponentRefs, 
-                                then the itemKind for each of these sub-ItemDefinitions must match the top-level ItemDefinition. 
+                                This defines the nature of the DataItem. Possible values are physical, information, conceptual, and others.
+                                The default value is information. If the ItemDefinition has itemComponents or itemComponentRefs,
+                                then the itemKind for each of these sub-ItemDefinitions must match the top-level ItemDefinition.
                             </xsd:documentation>
                         </xsd:annotation>
                     </xsd:element>
                     <xsd:element minOccurs="1" maxOccurs="1" name="multiplicityKindRef" type="sdmn:tMultiplicityKind">
                         <xsd:annotation>
                             <xsd:documentation>
-                                This setting the Multipliciy of the ItemDefinition. The default is ExactlyOne. This attribute MUST have the same value as the 
-                                multiplicty attribute of the associated DataItem. This 
+                                This setting the Multipliciy of the ItemDefinition. The default is ExactlyOne. This attribute MUST have the same value as the
+                                multiplicty attribute of the associated DataItem. This
                             </xsd:documentation>
                         </xsd:annotation>
                     </xsd:element>
-                </xsd:sequence>                
+                </xsd:sequence>
                 <xsd:attribute name="itemDefinitionRef" type="xsd:QName" use="optional">
                     <xsd:annotation>
                         <xsd:documentation>
-                            A reference to an external ItemDefinition that is imported into this Shared Data Model. The ItemDefinition and its details can 
-                            only be viewed in this model. Any changes to the original must be carried out in the source Shared Data Model. Other types of 
-                            structures are not allowed for the SDMN . However, BPMN Data Objects and CMMN Case File Items have the capability of references 
+                            A reference to an external ItemDefinition that is imported into this Shared Data Model. The ItemDefinition and its details can
+                            only be viewed in this model. Any changes to the original must be carried out in the source Shared Data Model. Other types of
+                            structures are not allowed for the SDMN . However, BPMN Data Objects and CMMN Case File Items have the capability of references
                             other types of structures. These other types of structures would not be a part of the SDMN Shared Data Model.
                         </xsd:documentation>
                     </xsd:annotation>
@@ -277,7 +277,7 @@
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>
-    
+
     <xsd:element name="Connector" abstract="true" type="sdmn:tConnector"/>
     <xsd:complexType name="tConnector">
         <xsd:complexContent>
@@ -315,14 +315,14 @@
             <xsd:extension base="sdmn:tConnector"/>
         </xsd:complexContent>
     </xsd:complexType>
-    
+
     <xsd:element name="ReferenceConnector" type="sdmn:tReferenceConnector" substitutionGroup="sdmn:Connector"/>
     <xsd:complexType name="tReferenceConnector">
         <xsd:complexContent>
             <xsd:extension base="sdmn:tConnector"/>
         </xsd:complexContent>
     </xsd:complexType>
-    
+
     <xsd:element name="DataAssociation" type="sdmn:tDataAssociation" substitutionGroup="sdmn:Connector"/>
     <xsd:complexType name="tDataAssociation">
         <xsd:complexContent>
@@ -331,22 +331,22 @@
                     <xsd:element maxOccurs="1" minOccurs="0" name="transformation" type="dmn:tLiteralExpression">
                         <xsd:annotation>
                             <xsd:documentation>
-                                Specifies an optional transformation Expression. The actual scope of accessible data for that Expression is 
-                                defined by the source and target of the specific Data Association types. 
+                                Specifies an optional transformation Expression. The actual scope of accessible data for that Expression is
+                                defined by the source and target of the specific Data Association types.
                             </xsd:documentation>
                         </xsd:annotation>
                     </xsd:element>
                     <xsd:element maxOccurs="unbounded" minOccurs="1" name="assignment" type="sdmn:tAssignment">
                         <xsd:annotation>
                             <xsd:documentation>
-                                Specifies one or more data elements Assignments. By using an Assignment, single data structure elements can be 
-                                assigned from the source structure to the target structure. 
+                                Specifies one or more data elements Assignments. By using an Assignment, single data structure elements can be
+                                assigned from the source structure to the target structure.
                             </xsd:documentation>
                         </xsd:annotation>
-                    </xsd:element>                    
+                    </xsd:element>
                 </xsd:sequence>
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>
-    
+
 </xsd:schema>

--- a/SDMN/SDMN.xsd
+++ b/SDMN/SDMN.xsd
@@ -7,7 +7,7 @@
     elementFormDefault="qualified"
     targetNamespace="https://www.omg.org/spec/SDMN/20211108/MODEL">
 
-    <xsd:import namespace="https://www.omg.org/spec/SCE/20211108/MODEL" schemaLocation="../SCE/SCE.xsd"/>  
+    <xsd:import namespace="https://www.omg.org/spec/SCE/20211108/MODEL" schemaLocation="../SCE/SCE.xsd"/>
     <xsd:import namespace="https://www.omg.org/spec/DMN/20191111/MODEL/"/>
     <xsd:import namespace="https://www.omg.org/spec/SDMN/20211108/SDMNDI" schemaLocation="SDMNDI.xsd"/>
     <xsd:include schemaLocation="SDMN-Semantic.xsd"/>
@@ -15,11 +15,11 @@
     <xsd:element name="SDMNModelPackage" type="tSDMNModelPackage">
         <xsd:annotation>
             <xsd:documentation>
-                The SDMNPackage class is the outermost containing object for all SDMN elements. It defines the scope of visibility and the namespace 
-                for all contained elements. The interchange of SDMN files will always be through one or more SDMNPackages. Specifically, an XML file 
+                The SDMNPackage class is the outermost containing object for all SDMN elements. It defines the scope of visibility and the namespace
+                for all contained elements. The interchange of SDMN files will always be through one or more SDMNPackages. Specifically, an XML file
                 for a Shared Data Model usually would be appended with a “.sdmn” label.
             </xsd:documentation>
-        </xsd:annotation>        
+        </xsd:annotation>
     </xsd:element>
     <xsd:complexType name="tSDMNModelPackage">
         <xsd:complexContent>
@@ -28,7 +28,7 @@
                     <xsd:element maxOccurs="1" minOccurs="0" name="model" type="tSDMNModel">
                         <xsd:annotation>
                             <xsd:documentation>
-                                This the SDMNModel sub-package contained within a SDMNModelPackage. This redefines the model association of SCEModelPackage. 
+                                This the SDMNModel sub-package contained within a SDMNModelPackage. This redefines the model association of SCEModelPackage.
                             </xsd:documentation>
                         </xsd:annotation>
                     </xsd:element>
@@ -46,5 +46,5 @@
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>
-    
+
 </xsd:schema>

--- a/SDMN/SDMNDI.xsd
+++ b/SDMN/SDMNDI.xsd
@@ -1,20 +1,20 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<xsd:schema elementFormDefault="qualified" 
-	targetNamespace="https://www.omg.org/spec/SDMN/20211108/SDMNDI" 
-	xmlns:sdmndi="https://www.omg.org/spec/SDMN/20211108/SDMNDI" 
-	xmlns:scedi="https://www.omg.org/spec/SCE/20211108/SCEDI" 
+<xsd:schema elementFormDefault="qualified"
+	targetNamespace="https://www.omg.org/spec/SDMN/20211108/SDMNDI"
+	xmlns:sdmndi="https://www.omg.org/spec/SDMN/20211108/SDMNDI"
+	xmlns:scedi="https://www.omg.org/spec/SCE/20211108/SCEDI"
 	xmlns:di="http://www.omg.org/spec/SCE/20210830/DI"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema">
 
 	<xsd:import namespace="https://www.omg.org/spec/SCE/20211108/SCEDI" schemaLocation="../SCE/SCEDI.xsd"/>
 	<xsd:import namespace="http://www.omg.org/spec/SCE/20210830/DI"/>
-	
+
     <xsd:element name="SDMNDI" type="sdmndi:tSDMNDI">
     	<xsd:annotation>
     		<xsd:documentation>
     			The class SDMNDI is a container for the shared SCE:SCEStyle and all the SDMNDiagrams defined in a SharedDataModel.
     		</xsd:documentation>
-    	</xsd:annotation>    	
+    	</xsd:annotation>
     </xsd:element>
 	<xsd:complexType name="tSDMNDI">
 		<xsd:complexContent>
@@ -42,15 +42,15 @@
 	<xsd:element name="SDMNDiagram" type="sdmndi:tSDMNDiagram" substitutionGroup="scedi:SCEDiagram">
     	<xsd:annotation>
     		<xsd:documentation>
-    			The class SDMNDiagram specializes SCE:SCEDiagram, which specializes DI::Diagram. It is a kind of Diagram that represents a depiction of 
-    			all or part of a SDMNDiagram. SDMNDiagram is the container of SDMNDiagramElement (SDMNShape(s) and SDMNEdge(s)). SDMNDiagram cannot include 
-    			other SDMNDiagrams. A SDMNDiagram can define a SCE:SCEStyle locally and/or it can refer to a shared one defined in the SDMNDI. Properties 
-    			defined in the local style overrides the one in the referenced shared style. That combined style (shared and local) is the default style 
-    			for all the SDMNDiagramElement contained in this SDMNDiagram. The SDMNDiagram class represents a two-dimensional surface with an origin of (0, 0) 
-    			at the top left corner. This means that the x and y axes have increasing coordinates to the right and bottom. Only positive coordinates are 
+    			The class SDMNDiagram specializes SCE:SCEDiagram, which specializes DI::Diagram. It is a kind of Diagram that represents a depiction of
+    			all or part of a SDMNDiagram. SDMNDiagram is the container of SDMNDiagramElement (SDMNShape(s) and SDMNEdge(s)). SDMNDiagram cannot include
+    			other SDMNDiagrams. A SDMNDiagram can define a SCE:SCEStyle locally and/or it can refer to a shared one defined in the SDMNDI. Properties
+    			defined in the local style overrides the one in the referenced shared style. That combined style (shared and local) is the default style
+    			for all the SDMNDiagramElement contained in this SDMNDiagram. The SDMNDiagram class represents a two-dimensional surface with an origin of (0, 0)
+    			at the top left corner. This means that the x and y axes have increasing coordinates to the right and bottom. Only positive coordinates are
     			allowed for diagram elements that are nested in a SDMNDiagram.
     		</xsd:documentation>
-    	</xsd:annotation>    	
+    	</xsd:annotation>
     </xsd:element>
 	<xsd:complexType name="tSDMNDiagram">
 		<xsd:complexContent>
@@ -60,7 +60,7 @@
 						<xsd:annotation>
 							<xsd:documentation>
 								Element Role: diagramElement
-								A list of SDMNDiagramElements (SDMNShape and SDMNEdge) that are depicted in the SDMNDiagram. 
+								A list of SDMNDiagramElements (SDMNShape and SDMNEdge) that are depicted in the SDMNDiagram.
 								This redefines the diagramElement association within the SCE:SCEDiagram element.
 							</xsd:documentation>
 						</xsd:annotation>
@@ -74,10 +74,10 @@
 		<xsd:annotation>
 			<xsd:documentation>
 				This element should never be instantiated directly, but rather concrete implementation should. It is placed there only to be referred in the sequence.
-				The SDMNDiagramElement class is contained by the SDMNDiagram and is the base class for SDMNShape and SDMNEdge. 
-				SDMNDiagramElement inherits its styling from its parent SCEDiagram. In addition, it can refer to one of the shared 
-				SCE:SCEStyle defined in the SDMNDI and/or it can define a local style. See section below for more details on styling. 
-				SDMNDiagramElement MAY also contain a SCE:SCELabel when it has a visible text label. If no SCE:SCELabel is defined, the 
+				The SDMNDiagramElement class is contained by the SDMNDiagram and is the base class for SDMNShape and SDMNEdge.
+				SDMNDiagramElement inherits its styling from its parent SCEDiagram. In addition, it can refer to one of the shared
+				SCE:SCEStyle defined in the SDMNDI and/or it can define a local style. See section below for more details on styling.
+				SDMNDiagramElement MAY also contain a SCE:SCELabel when it has a visible text label. If no SCE:SCELabel is defined, the
 				SDMNDiagramElement should be depicted without a label.
 			</xsd:documentation>
 		</xsd:annotation>
@@ -85,15 +85,15 @@
 
     <xsd:element name="SDMNEdge" type="sdmndi:tSDMNEdge" substitutionGroup="sdmndi:SDMNDiagramElement">
     	<xsd:annotation>
-    		<xsd:documentation>The SDMNEdge class specializes SCE:SCEEdge, which specializes DI::Edge and SCE:SCEDiagramElement. It is a kind of edge that can depict 
-    			a relationship between two SDMNDiagram model elements. SDMNEdge are used to depict Connectors or Associations in the SDMNDiagram model. Since 
-    			SDMNDiagramElement might be depicted more than once, sourceElement and targetElement attributes allow to determine to which depiction a SDMNEdge is 
-    			connected. When SDMNEdge has a source, its sourceModelElement MUST refer to the SDMNDiagramElement it starts from. That SDMNDiagramElement MUST 
-    			resolved to the SCE:SCEElement that is the actual source of the Connector or Association. For Requirement, this is the required SCE:SCEElement. 
-    			When it has a target, its targetModelElement MUST refer to the SCEDiagramElement where it ends. That SDMNDiagramElement MUST resolved to the 
+    		<xsd:documentation>The SDMNEdge class specializes SCE:SCEEdge, which specializes DI::Edge and SCE:SCEDiagramElement. It is a kind of edge that can depict
+    			a relationship between two SDMNDiagram model elements. SDMNEdge are used to depict Connectors or Associations in the SDMNDiagram model. Since
+    			SDMNDiagramElement might be depicted more than once, sourceElement and targetElement attributes allow to determine to which depiction a SDMNEdge is
+    			connected. When SDMNEdge has a source, its sourceModelElement MUST refer to the SDMNDiagramElement it starts from. That SDMNDiagramElement MUST
+    			resolved to the SCE:SCEElement that is the actual source of the Connector or Association. For Requirement, this is the required SCE:SCEElement.
+    			When it has a target, its targetModelElement MUST refer to the SCEDiagramElement where it ends. That SDMNDiagramElement MUST resolved to the
     			SCE:SCEElement that is the actual target of the Connector or Association.
     		</xsd:documentation>
-    	</xsd:annotation>    	
+    	</xsd:annotation>
     </xsd:element>
 	<xsd:complexType name="tSDMNEdge">
 		<xsd:complexContent>
@@ -103,13 +103,13 @@
 
 	<xsd:element name="SDMNShape" type="sdmndi:tSDMNShape" substitutionGroup="sdmndi:SDMNDiagramElement">
     	<xsd:annotation>
-    		<xsd:documentation>The SDMNShape class specializes SCE:SCEShape, which specializes DI::Shape and SCE:SCEDiagramElement. It is a kind of shape that depicts a 
-    			SCEElement from the SDMNDiagram model. SDMNShape represents a Data Item or a SCE DiagramArtifacts Group or a Text Annotation that is depicted on the 
-    			diagram. SDMNDiagram models may add additional shapes to their diagrams. SDMNShape has no additional properties but a SDMNDiagram model may extend this 
+    		<xsd:documentation>The SDMNShape class specializes SCE:SCEShape, which specializes DI::Shape and SCE:SCEDiagramElement. It is a kind of shape that depicts a
+    			SCEElement from the SDMNDiagram model. SDMNShape represents a Data Item or a SCE DiagramArtifacts Group or a Text Annotation that is depicted on the
+    			diagram. SDMNDiagram models may add additional shapes to their diagrams. SDMNShape has no additional properties but a SDMNDiagram model may extend this
     			class to add properties that are used to further specify the appearance of some shapes that cannot be deduced from the SDMNDiagram model.
     		</xsd:documentation>
-    	</xsd:annotation>    	
-    </xsd:element>	
+    	</xsd:annotation>
+    </xsd:element>
 	<xsd:complexType name="tSDMNShape">
 		<xsd:complexContent>
 			<xsd:extension base="scedi:tSCEShape"/>


### PR DESCRIPTION
There's a lot of trailing spaces in the documents. This makes the file unnecessarily bigger, and also forces maintainers to turn off auto-trimming.