### PR TITLE
SCE-2/SCE-52 Add expressionLanguage and typeLanguage attributes

### DIFF
--- a/SCE/SCE.xsd
+++ b/SCE/SCE.xsd
@@ -40,6 +40,8 @@
 						</xsd:annotation>
 					</xsd:element>
 				</xsd:sequence>
+				<xsd:attribute name="expressionLanguage" type="xsd:anyURI" use="optional" default="https://www.omg.org/spec/DMN/20230324/FEEL/"/>
+				<xsd:attribute name="typeLanguage" type="xsd:anyURI" use="optional" default="https://www.omg.org/spec/DMN/20230324/FEEL/"/>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>


### PR DESCRIPTION
Issue: [SCE-2 Common attributes expressionLanguage and typeLanguage are missing](https://issues.omg.org/browse/SCE-2)
Proposal: [SCE-52 Include expressionLanguage and typeLanguage with default values](https://issues.omg.org/browse/SCE-52)

