### PR TITLE
SCE-47/SCE-79 Fix capitalization of humanId & aliasId

### DIFF
--- a/SCE/SCE-Semantic.xsd
+++ b/SCE/SCE-Semantic.xsd
@@ -438,7 +438,7 @@
 		</xsd:annotation>
 	</xsd:element>
 	<xsd:complexType name="tSCERootElement">
-		<xsd:attribute name="aliasID" type="xsd:string" use="optional">
+		<xsd:attribute name="aliasId" type="xsd:string" use="optional">
 			<xsd:annotation>
 				<xsd:documentation>
 					Various alternative identifiers for this Element. Generally, these will be set by tools, but one of them (the humanId), in particular, 
@@ -446,7 +446,7 @@
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		<xsd:attribute name="humanID" type="xsd:string" use="optional">
+		<xsd:attribute name="humanId" type="xsd:string" use="optional">
 			<xsd:annotation>
 				<xsd:documentation>
 					An identifier for this Element that is set by the modeler. It is the responsibility of the modeler to maintain the uniqueness of 


### PR DESCRIPTION
Issue: [SCE-47 Inconsistent capitalization in humanID and aliasID compared to id](https://issues.omg.org/browse/SCE-47)
Proposal: [SCE-79 Update capitalization for humanID and aliasID](https://issues.omg.org/browse/SCE-79)
