### PR TITLE
SCE-53/SCE-84 Allow direct use of SCE's DI classes

### DIFF
--- a/SCE/DC.xsd
+++ b/SCE/DC.xsd
@@ -5,28 +5,28 @@
 		xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 		elementFormDefault="qualified">
 
-	<xsd:element name="Color" type="dc:Color"/>
-	<xsd:element name="Point" type="dc:Point"/>
-	<xsd:element name="Bounds" type="dc:Bounds"/>
-	<xsd:element name="Dimension" type="dc:Dimension"/>
+	<xsd:element name="Color" type="dc:tColor"/>
+	<xsd:element name="Point" type="dc:tPoint"/>
+	<xsd:element name="Bounds" type="dc:tBounds"/>
+	<xsd:element name="Dimension" type="dc:tDimension"/>
 
-	<xsd:complexType name="Color">
+	<xsd:complexType name="tColor">
 		<xsd:annotation>
 			<xsd:documentation>Color is a data type that represents a color value in the RGB format.</xsd:documentation>
 		</xsd:annotation>
-		<xsd:attribute name="red" type="dc:rgb" use="required"/>
-		<xsd:attribute name="green" type="dc:rgb" use="required"/>
-		<xsd:attribute name="blue" type="dc:rgb" use="required"/>
+		<xsd:attribute name="red" type="dc:tRGB" use="required"/>
+		<xsd:attribute name="green" type="dc:tRGB" use="required"/>
+		<xsd:attribute name="blue" type="dc:tRGB" use="required"/>
 	</xsd:complexType>
 
-	<xsd:simpleType name="rgb">
+	<xsd:simpleType name="tRGB">
 		<xsd:restriction base="xsd:int">
 			<xsd:minInclusive value="0"/>
 			<xsd:maxInclusive value="255"/>
 		</xsd:restriction>
 	</xsd:simpleType>
 
-	<xsd:complexType name="Point">
+	<xsd:complexType name="tPoint">
 		<xsd:annotation>
 			<xsd:documentation>A Point specifies an location in some x-y coordinate system.</xsd:documentation>
 		</xsd:annotation>
@@ -34,7 +34,7 @@
 		<xsd:attribute name="y" type="xsd:double" use="required"/>
 	</xsd:complexType>
 
-	<xsd:complexType name="Dimension">
+	<xsd:complexType name="tDimension">
 		<xsd:annotation>
 			<xsd:documentation>Dimension specifies two lengths (width and height) along the x and y axes in some x-y coordinate system.</xsd:documentation>
 		</xsd:annotation>
@@ -42,7 +42,7 @@
 		<xsd:attribute name="height" type="xsd:double" use="required"/>
 	</xsd:complexType>
 
-	<xsd:complexType name="Bounds">
+	<xsd:complexType name="tBounds">
 	   <xsd:annotation>
 			<xsd:documentation>Bounds specifies a rectangular area in some x-y coordinate system that is defined by a location (x and y) and a size (width and height).</xsd:documentation>
 		</xsd:annotation>
@@ -52,7 +52,7 @@
 		<xsd:attribute name="height" type="xsd:double" use="required"/>
 	</xsd:complexType>
 
-	<xsd:simpleType name="AlignmentKind">
+	<xsd:simpleType name="tAlignmentKind">
 		<xsd:annotation>
 			<xsd:documentation>AlignmentKind enumerates the possible options for alignment for layout purposes.</xsd:documentation>
 		</xsd:annotation>
@@ -63,7 +63,7 @@
 		</xsd:restriction>
 	</xsd:simpleType>
 
-	<xsd:simpleType name="KnownColor">
+	<xsd:simpleType name="tKnownColor">
 		<xsd:annotation>
 			<xsd:documentation>KnownColor is an enumeration of 17 known colors.</xsd:documentation>
 		</xsd:annotation>

--- a/SCE/DC.xsd
+++ b/SCE/DC.xsd
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-			xmlns:dc="http://www.omg.org/spec/SCE/20210830/DC"
-			targetNamespace="http://www.omg.org/spec/SCE/20210830/DC"
-            elementFormDefault="qualified"
-            attributeFormDefault="unqualified">
+<xsd:schema id="DC" version="1.1-SCE1.0"
+		targetNamespace="http://www.omg.org/spec/SCE/20210830/DC"
+		xmlns:dc="http://www.omg.org/spec/SCE/20210830/DC"
+		xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+		elementFormDefault="qualified">
 
 	<xsd:element name="Color" type="dc:Color"/>
 	<xsd:element name="Point" type="dc:Point"/>

--- a/SCE/DI.xsd
+++ b/SCE/DI.xsd
@@ -43,17 +43,6 @@
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="id" type="xsd:ID" use="optional"/>
-		<xsd:attribute name="modelElement" type="xsd:QName" use="optional">
-			<xsd:annotation>
-				<xsd:documentation>
-					a reference to the model element represented by this diagram element.
-					It is optional for Diagrams, but MUST be set on Shapes and Edges.
-					Note that the sourceElement or targetElement attributes of Edge MUST ONLY
-					be present if the Edge is depicted between a different source or target than the
-					one referenced by the modelElement of the Edge.
-				</xsd:documentation>
-			</xsd:annotation>
-		</xsd:attribute>
 		<xsd:anyAttribute namespace="##other" processContents="lax"/>
 	</xsd:complexType>
 
@@ -111,24 +100,6 @@
 						</xsd:annotation>
 					</xsd:element>
 				</xsd:sequence>
-				<xsd:attribute name="sourceElement" type="xsd:QName" use="optional">
-					<xsd:annotation>
-						<xsd:documentation>
-							an optional reference to the DiagramElement that this Edge starts from.
-							This attribute MUST ONLY be present if the Edge is depicted starting from
-							a different source than the one referenced by the modelElement of the Edge.
-						</xsd:documentation>
-					</xsd:annotation>
-				</xsd:attribute>
-				<xsd:attribute name="targetElement" type="xsd:QName" use="optional">
-					<xsd:annotation>
-						<xsd:documentation>
-							an optional reference to the DiagramElement that this Edge ends at.
-							This attribute MUST ONLY be present if the Edge is depicted ending at
-							a different target than the one referenced by the modelElement of the Edge.
-						</xsd:documentation>
-					</xsd:annotation>
-				</xsd:attribute>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>

--- a/SCE/DI.xsd
+++ b/SCE/DI.xsd
@@ -16,13 +16,13 @@
 		</xsd:documentation>
 	</xsd:annotation>
 
-	<xsd:element name="Style" type="di:Style">
+	<xsd:element name="Style" type="di:tStyle">
 		<xsd:annotation>
 			<xsd:documentation>This element should never be instantiated directly, but rather concrete implementation should. It is placed there only to be referred in the sequence</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 
-	<xsd:complexType name="DiagramElement" abstract="true">
+	<xsd:complexType name="tDiagramElement" abstract="true">
 		<xsd:annotation>
 			<xsd:documentation>
 				DiagramElement is the abstract super type of all elements in diagrams, including diagrams themselves. 
@@ -65,9 +65,9 @@
 		</xsd:complexType>
 	</xsd:element>
 
-	<xsd:complexType name="Diagram" abstract="true">
+	<xsd:complexType name="tDiagram" abstract="true">
 		<xsd:complexContent>
-			<xsd:extension base="di:DiagramElement">			
+			<xsd:extension base="di:tDiagramElement">			
 				<xsd:attribute name="name" type="xsd:string">
 					<xsd:annotation>
 						<xsd:documentation>the name of the diagram.</xsd:documentation>
@@ -87,9 +87,9 @@
 		</xsd:complexContent>
 	</xsd:complexType>
 
-	<xsd:complexType name="Shape" abstract="true">
+	<xsd:complexType name="tShape" abstract="true">
 		<xsd:complexContent>
-			<xsd:extension base="di:DiagramElement">
+			<xsd:extension base="di:tDiagramElement">
 				<xsd:sequence>
 					<xsd:element ref="dc:Bounds" minOccurs="0" maxOccurs="1">
 						<xsd:annotation>
@@ -101,11 +101,11 @@
 		</xsd:complexContent>
 	</xsd:complexType>
 
-	<xsd:complexType name="Edge" abstract="true">
+	<xsd:complexType name="tEdge" abstract="true">
 		<xsd:complexContent>
-			<xsd:extension base="di:DiagramElement">
+			<xsd:extension base="di:tDiagramElement">
 				<xsd:sequence>
-					<xsd:element name="waypoint" type="dc:Point" minOccurs="0" maxOccurs="unbounded">
+					<xsd:element name="waypoint" type="dc:tPoint" minOccurs="0" maxOccurs="unbounded">
 						<xsd:annotation>
 							<xsd:documentation>an optional list of points relative to the origin of the nesting diagram that specifies the connected line segments of the edge</xsd:documentation>
 						</xsd:annotation>
@@ -133,7 +133,7 @@
 		</xsd:complexContent>
 	</xsd:complexType>
 
-	<xsd:complexType name="Style" abstract="true">
+	<xsd:complexType name="tStyle" abstract="true">
 		<xsd:annotation>
 			<xsd:documentation>Style contains formatting properties that affect the appearance or style of diagram elements, including diagram themselves.</xsd:documentation>
 		</xsd:annotation>

--- a/SCE/DI.xsd
+++ b/SCE/DI.xsd
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-			xmlns:dc="http://www.omg.org/spec/SCE/20210830/DC"
-			xmlns:di="http://www.omg.org/spec/SCE/20210830/DI"
-			targetNamespace="http://www.omg.org/spec/SCE/20210830/DI"
-            elementFormDefault="qualified"
-            attributeFormDefault="unqualified">
-	<xsd:import namespace="http://www.omg.org/spec/SCE/20210830/DC" schemaLocation="DC.xsd"/>
+<xsd:schema id="DI" version="1.1-SCE1.0"
+		targetNamespace="http://www.omg.org/spec/SCE/20210830/DI"
+		xmlns:di="http://www.omg.org/spec/SCE/20210830/DI"
+		xmlns:dc="http://www.omg.org/spec/SCE/20210830/DC"
+		xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+		elementFormDefault="qualified">
+	<xsd:import namespace="http://www.omg.org/spec/SCE/20210830/DC"
+			schemaLocation="DC.xsd"/>
 
 	<xsd:annotation>
 		<xsd:documentation>
@@ -23,18 +24,13 @@
 
 	<xsd:complexType name="DiagramElement" abstract="true">
 		<xsd:annotation>
-			<xsd:documentation>DiagramElement is the abstract super type of all elements in diagrams, including diagrams themselves. 
+			<xsd:documentation>
+				DiagramElement is the abstract super type of all elements in diagrams, including diagrams themselves. 
 				When contained in a diagram, diagram elements are laid out relative to the diagram's origin.
 			</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element name="extension" minOccurs="0">
-				<xsd:complexType>
-					<xsd:sequence>
-						<xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded" /> 
-					</xsd:sequence>
-				</xsd:complexType>
-			</xsd:element>
+			<xsd:element ref="di:extension" minOccurs="0" maxOccurs="1"/>
 			<xsd:element ref="di:Style" minOccurs="0" maxOccurs="1">
 				<xsd:annotation>
 					<xsd:documentation>an optional locally-owned style for this diagram element.</xsd:documentation>
@@ -46,9 +42,28 @@
 				<xsd:documentation>a reference to an optional shared style element for this diagram element.</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		<xsd:attribute name="id" type="xsd:ID"/>
+		<xsd:attribute name="id" type="xsd:ID" use="optional"/>
+		<xsd:attribute name="modelElement" type="xsd:QName" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					a reference to the model element represented by this diagram element.
+					It is optional for Diagrams, but MUST be set on Shapes and Edges.
+					Note that the sourceElement or targetElement attributes of Edge MUST ONLY
+					be present if the Edge is depicted between a different source or target than the
+					one referenced by the modelElement of the Edge.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
 		<xsd:anyAttribute namespace="##other" processContents="lax"/>
 	</xsd:complexType>
+
+	<xsd:element name="extension">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded" /> 
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
 
 	<xsd:complexType name="Diagram" abstract="true">
 		<xsd:complexContent>
@@ -96,6 +111,24 @@
 						</xsd:annotation>
 					</xsd:element>
 				</xsd:sequence>
+				<xsd:attribute name="sourceElement" type="xsd:QName" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>
+							an optional reference to the DiagramElement that this Edge starts from.
+							This attribute MUST ONLY be present if the Edge is depicted starting from
+							a different source than the one referenced by the modelElement of the Edge.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="targetElement" type="xsd:QName" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>
+							an optional reference to the DiagramElement that this Edge ends at.
+							This attribute MUST ONLY be present if the Edge is depicted ending at
+							a different target than the one referenced by the modelElement of the Edge.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>

--- a/SCE/SCE.xsd
+++ b/SCE/SCE.xsd
@@ -63,10 +63,10 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element ref="scedi:SCEDI" minOccurs="0" maxOccurs="unbounded">
+					<xsd:element ref="scedi:SCEDiagrams" minOccurs="0" maxOccurs="unbounded">
 						<xsd:annotation>
 							<xsd:documentation>
-								This attribute contains the Diagram Interchange information contained within this SCEModelPackage.
+								This element contains the Diagram Interchange information contained within this SCEModelPackage.
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>

--- a/SCE/SCEDI.xsd
+++ b/SCE/SCEDI.xsd
@@ -54,9 +54,9 @@
 	</xsd:element>
 	<xsd:complexType name="tSCEDiagram">
 		<xsd:complexContent>
-			<xsd:extension base="di:Diagram">
+			<xsd:extension base="di:tDiagram">
 				<xsd:sequence>
-					<xsd:element name="Size" type="dc:Dimension" minOccurs="0" maxOccurs="1">
+					<xsd:element name="Size" type="dc:tDimension" minOccurs="0" maxOccurs="1">
 						<xsd:annotation>
 							<xsd:documentation>
 								The size of this diagram. If not specified, the the SCE-dependent diagram is unbounded.
@@ -93,7 +93,7 @@
 		</xsd:complexContent>
 	</xsd:complexType>
 
-	<xsd:element name="SCEDiagramElement" type="di:DiagramElement" abstract="true">
+	<xsd:element name="SCEDiagramElement" type="di:tDiagramElement" abstract="true">
 		<xsd:annotation>
 			<xsd:documentation>
 				The SCEDiagramElement class is contained by the SCEDiagram and is the base class for DMNShape and DMNEdge. SCEDiagramElement inherits its styling 
@@ -119,7 +119,7 @@
 	</xsd:element>
 	<xsd:complexType name="tSCEEdge">
 		<xsd:complexContent>
-			<xsd:extension base="di:Edge">
+			<xsd:extension base="di:tEdge">
 				<xsd:sequence>
 					<xsd:element ref="scedi:SCELabel" minOccurs="0" maxOccurs="1">
 						<xsd:annotation>
@@ -147,7 +147,7 @@
 			</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
-			<xsd:extension base="di:Shape">
+			<xsd:extension base="di:tShape">
 				<xsd:attribute name="text" type="xsd:string" use="optional"/>
 			</xsd:extension>
 			<!-- DS changed type from xsd:String to xsd:string (case sensitive) -->
@@ -165,7 +165,7 @@
 			</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
-			<xsd:extension base="di:Shape">
+			<xsd:extension base="di:tShape">
 				<xsd:sequence>
 					<xsd:element ref="scedi:SCELabel" minOccurs="0" maxOccurs="1">
 						<xsd:annotation>
@@ -206,9 +206,9 @@
 	</xsd:element>
 	<xsd:complexType name="tSCEStyle">
 		<xsd:complexContent>
-			<xsd:extension base="di:Style">
+			<xsd:extension base="di:tStyle">
 				<xsd:sequence>
-					<xsd:element name="fillColor" type="dc:Color" minOccurs="0" maxOccurs="1">
+					<xsd:element name="fillColor" type="dc:tColor" minOccurs="0" maxOccurs="1">
 						<xsd:annotation>
 							<xsd:documentation>
 								The color use to fill the shape. Does not apply to SCEEdge.
@@ -216,14 +216,14 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element name="strokeColor" type="dc:Color" minOccurs="0" maxOccurs="1">
+					<xsd:element name="strokeColor" type="dc:tColor" minOccurs="0" maxOccurs="1">
 						<xsd:annotation>
 							<xsd:documentation>
 								The color use to draw the shape borders. The default is black.
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element name="fontColor" type="dc:Color" minOccurs="0" maxOccurs="1">
+					<xsd:element name="fontColor" type="dc:tColor" minOccurs="0" maxOccurs="1">
 						<xsd:annotation>
 							<xsd:documentation>
 								The color use to write the label. The default is black.
@@ -237,7 +237,7 @@
 				<xsd:attribute name="fontItalic" type="xsd:boolean" use="optional" default="false"/>
 				<xsd:attribute name="fontSize" type="xsd:double" use="optional" default="8"/>
 				<xsd:attribute name="fontFamily" type="xsd:string" use="optional" default="Arial"/>
-				<xsd:attribute name="labelHorizontalAlignment" type="dc:AlignmentKind" use="optional">
+				<xsd:attribute name="labelHorizontalAlignment" type="dc:tAlignmentKind" use="optional">
 					<xsd:annotation>
 						<xsd:documentation>
 							How text should be positioned horizontally within the Label bounds. Default depends
@@ -245,7 +245,7 @@
 						</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
-				<xsd:attribute name="labelVerticalAlignment" type="dc:AlignmentKind" use="optional">
+				<xsd:attribute name="labelVerticalAlignment" type="dc:tAlignmentKind" use="optional">
 					<xsd:annotation>
 						<xsd:documentation>
 							How the text should be positioned vertically inside the Label bounds. Default

--- a/SCE/SCEDI.xsd
+++ b/SCE/SCEDI.xsd
@@ -10,14 +10,14 @@
 	<xsd:import namespace="http://www.omg.org/spec/SCE/20210830/DC" schemaLocation="DC.xsd"/>
 	<xsd:import namespace="http://www.omg.org/spec/SCE/20210830/DI" schemaLocation="DI.xsd"/>
 
-	<xsd:element name="SCEDI" type="scedi:tSCEDI">
+	<xsd:element name="SCEDiagrams" type="scedi:tSCEDiagrams">
 		<xsd:annotation>
 			<xsd:documentation>
-				The class SCEDI is a container for the shared SCEStyle and all the SCEDiagram defined in a SCE-dependent modeling package.
+				The class SCEDiagrams is a container for all the SCEDiagram and the shared SCEStyle defined in a SCE-dependent modeling package.
 			</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="tSCEDI">
+	<xsd:complexType name="tSCEDiagrams">
 		<xsd:sequence>
 			<xsd:element ref="scedi:SCEDiagram" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
@@ -33,14 +33,16 @@
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element ref="di:extension" minOccurs="0" maxOccurs="1"/>
 		</xsd:sequence>				
 	</xsd:complexType>
 
-	<xsd:element name="SCEDiagram" type="scedi:tSCEDiagram" abstract="true">
+	<xsd:element name="SCEDiagram" type="scedi:tSCEDiagram">
 		<xsd:annotation>
 			<xsd:documentation>
-				The abstract class SCEDiagram specializes DI::Diagram. It is a kind of Diagram that represents a depiction of all or part of a SCE-dependent model. 
-				It is contained within the SCEDI element. The languages that are dependent on SCE will define concrete diagrams based on SCEDiagram.
+				The class SCEDiagram specializes DI::Diagram. It is a kind of Diagram that represents a depiction of all or part of a SCE-dependent model. 
+				It is contained within the SCEDI element. The languages that are dependent on SCE MAY define specialized diagrams based on SCEDiagram
+				if they have to add new elements or attributes. By default they should use SCEDiagram directly.
 				SCEDiagram is the container of SCEDiagramElement (SCEShape(s) and SCEEdge(s)). SCEDiagram cannot include other SCEDiagrams. A SCEDiagram can 
 				define a SCEStyle locally and/or it can refer to a shared one defined in the SCEDI. Properties defined in the local style overrides
 				the one in the referenced shared style. That combined style (shared and local) is the default style for all the SCEDiagramElement contained 
@@ -54,19 +56,19 @@
 		<xsd:complexContent>
 			<xsd:extension base="di:Diagram">
 				<xsd:sequence>
+					<xsd:element name="Size" type="dc:Dimension" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>
+								The size of this diagram. If not specified, the the SCE-dependent diagram is unbounded.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
 					<xsd:element ref="scedi:SCEDiagramElement" minOccurs="0" maxOccurs="unbounded">
 						<xsd:annotation>
 							<xsd:documentation>
 								Element Role: diagramElement
 								A list of SCEDiagramElements (SCEShape and SCEEdge) that are depicted in the
 								SCE-dependent diagram. The diagram elements are ordered.
-							</xsd:documentation>
-						</xsd:annotation>
-					</xsd:element>
-					<xsd:element name="size" type="dc:Dimension" minOccurs="0" maxOccurs="1">
-						<xsd:annotation>
-							<xsd:documentation>
-								The size of this diagram. If not specified, the the SCE-dependent diagram is unbounded.
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
@@ -119,20 +121,6 @@
 		<xsd:complexContent>
 			<xsd:extension base="di:Edge">
 				<xsd:sequence>
-					<xsd:element name="targetElementRef" type="xsd:QName" minOccurs="0" maxOccurs="1">
-						<xsd:annotation>
-							<xsd:documentation>
-								The actual SCEDiagramElement this SCEEdge is connecting to. This MUST be specified when the SCEEdge has a target.
-							</xsd:documentation>
-						</xsd:annotation>
-					</xsd:element>
-					<xsd:element name="sourceElementRef" type="xsd:QName" minOccurs="0" maxOccurs="1">
-						<xsd:annotation>
-							<xsd:documentation>
-								The actual SCEDiagramElement this SCEEdge is connecting from. This MUST be specified when the SCEEdge has a source.
-							</xsd:documentation>
-						</xsd:annotation>
-					</xsd:element>
 					<xsd:element ref="scedi:SCELabel" minOccurs="0" maxOccurs="1">
 						<xsd:annotation>
 							<xsd:documentation>
@@ -188,14 +176,6 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element name="sceElementRef" type="xsd:QName" minOccurs="1" maxOccurs="1">
-						<xsd:annotation>
-							<xsd:documentation>
-								This element is added to Shape because the dual inheritence of the UML metamodel is not supported in XSD.
-								A reference to the SCEElement that is being depicted.                
-							</xsd:documentation>
-						</xsd:annotation>
-					</xsd:element>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -231,7 +211,8 @@
 					<xsd:element name="fillColor" type="dc:Color" minOccurs="0" maxOccurs="1">
 						<xsd:annotation>
 							<xsd:documentation>
-								The color use to write the label. The default is black.
+								The color use to fill the shape. Does not apply to SCEEdge.
+								The default is white.
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
@@ -249,30 +230,30 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element name="labelHorizontalAlignement" type="dc:AlignmentKind" minOccurs="0" maxOccurs="1">
-						<xsd:annotation>
-							<xsd:documentation>
-								How text should be positioned horizontally within the Label bounds. Default depends
-								of the SCEDiagramElement the label is attached to (see section below).
-							</xsd:documentation>
-						</xsd:annotation>
-					</xsd:element>
-					<xsd:element name="labelVerticalAlignment" type="dc:AlignmentKind" minOccurs="0" maxOccurs="1">
-						<xsd:annotation>
-							<xsd:documentation>
-								How the text should be positioned vertically inside the Label bounds. Default
-								depends of the SCEDiagramElement the label is attached to (see section below). Start
-								means “top” and end means “bottom”.
-							</xsd:documentation>
-						</xsd:annotation>
-					</xsd:element>
 				</xsd:sequence>
-				<xsd:attribute name="fontStrikeThrough" type="xsd:boolean" use="optional"/>
-				<xsd:attribute name="fontUnderline" type="xsd:boolean" use="optional"/>
-				<xsd:attribute name="fontBold" type="xsd:boolean" use="optional"/>
-				<xsd:attribute name="fontItalic" type="xsd:boolean" use="optional"/>
-				<xsd:attribute name="fontSize" type="xsd:double" use="optional"/>
-				<xsd:attribute name="fontFamily" type="xsd:string" use="optional"/>
+				<xsd:attribute name="fontStrikeThrough" type="xsd:boolean" use="optional" default="false"/>
+				<xsd:attribute name="fontUnderline" type="xsd:boolean" use="optional" default="false"/>
+				<xsd:attribute name="fontBold" type="xsd:boolean" use="optional" default="false"/>
+				<xsd:attribute name="fontItalic" type="xsd:boolean" use="optional" default="false"/>
+				<xsd:attribute name="fontSize" type="xsd:double" use="optional" default="8"/>
+				<xsd:attribute name="fontFamily" type="xsd:string" use="optional" default="Arial"/>
+				<xsd:attribute name="labelHorizontalAlignment" type="dc:AlignmentKind" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>
+							How text should be positioned horizontally within the Label bounds. Default depends
+							of the SCEDiagramElement the label is attached to (see section below).
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="labelVerticalAlignment" type="dc:AlignmentKind" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>
+							How the text should be positioned vertically inside the Label bounds. Default
+							depends of the SCEDiagramElement the label is attached to (see section below). Start
+							means “top” and end means “bottom”.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>

--- a/SCE/SCEDI.xsd
+++ b/SCE/SCEDI.xsd
@@ -89,6 +89,13 @@
 						</xsd:annotation>
 					</xsd:element>
 				</xsd:sequence>
+				<xsd:attribute name="modelElement" type="xsd:QName" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>
+							a reference to the Element represented by this Diagram.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
@@ -131,6 +138,34 @@
 						</xsd:annotation>
 					</xsd:element>
 				</xsd:sequence>
+				<xsd:attribute name="modelElement" type="xsd:QName" use="required">
+					<xsd:annotation>
+						<xsd:documentation>
+							a reference to the Element represented by this Edge.
+							Note that the sourceElement or targetElement attributes of Edge MUST ONLY
+							be present if the Edge is depicted between a different source or target than the
+							one referenced by the modelElement of the Edge.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="sourceElement" type="xsd:QName" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>
+							an optional reference to the DiagramElement that this Edge starts from.
+							This attribute MUST ONLY be present if the Edge is depicted starting from
+							a different source than the one referenced by the modelElement of the Edge.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="targetElement" type="xsd:QName" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>
+							an optional reference to the DiagramElement that this Edge ends at.
+							This attribute MUST ONLY be present if the Edge is depicted ending at
+							a different target than the one referenced by the modelElement of the Edge.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
@@ -177,6 +212,13 @@
 						</xsd:annotation>
 					</xsd:element>
 				</xsd:sequence>
+				<xsd:attribute name="modelElement" type="xsd:QName" use="required">
+					<xsd:annotation>
+						<xsd:documentation>
+							a reference to the Element represented by this Shape.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>


### PR DESCRIPTION
Issue: [SCE-53 SCEDI cannot be directly re-used as-is](https://issues.omg.org/browse/SCE-53)
Proposal: [SCE-84 Update SCEDI classes to allow direct re-use by other languages](https://issues.omg.org/browse/SCE-84)
